### PR TITLE
ci: publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # required for npm trusted publishing (OIDC)
+      id-token: write
     env:
       NODE_ENV: production
       CI: true
@@ -75,7 +77,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          registry-url: https://registry.npmjs.org
+
+      # trusted publishing needs npm >= 11.5.1, node 22 still ships npm 10
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -93,8 +98,7 @@ jobs:
           publish: bun run release
           commit: "chore: version packages"
           title: "chore: version packages"
+        # no NPM_TOKEN on purpose: without it changesets/action leaves the npm
+        # credentials alone and npm authenticates via OIDC instead
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The 1.1.10 release failed to publish. `changeset publish` got a 404 on `PUT https://registry.npmjs.org/list-config-plugins`, which is how npm reports "these credentials may not write to this package". The `NPM_TOKEN` secret dates from 2026-02-18 — the day 1.1.9 was published, the last release that worked — and npm granular tokens live at most 90 days, so it is long expired.

## What changed

Authenticate with npm trusted publishing (OIDC) instead of a long lived token:

- add the `id-token: write` permission to the release job
- drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` / `NPM_CONFIG_TOKEN` from the changesets step. `changesets/action@v1` only touches `.npmrc` when `NPM_TOKEN` is set; without it, it detects OIDC and leaves auth to npm
- drop `registry-url` from `setup-node` in that job, so it no longer writes an `.npmrc` whose `${NODE_AUTH_TOKEN}` placeholder would shadow the OIDC flow
- upgrade npm before publishing, since trusted publishing needs npm >= 11.5.1 and node 22 ships npm 10

No credential can expire on us again, and releases now carry build provenance.

## Setup this depends on

The trusted publisher must be registered on npmjs.com for `list-config-plugins`: GitHub Actions, repo `WookieFPV/list-config-plugins`, workflow `release.yml`. The stale `NPM_TOKEN` secret can be deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)